### PR TITLE
Remove eventslib reference for 3.6+

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -35,7 +35,6 @@ defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
 
-require_once($CFG->dirroot.'/lib/eventslib.php');
 require_once($CFG->dirroot.'/lib/formslib.php');
 require_once($CFG->dirroot.'/calendar/lib.php');
 require_once($CFG->dirroot.'/lib/gradelib.php');


### PR DESCRIPTION
This plugin was migrated to Events 2 API back in 2016 - https://github.com/ULCC/open-mod_coursework/edit/Moodle_34/README.md#L104 so this should not be needed for backwards compatibility.

Alternative would be to replace reference with deprecatedlib.php but doing so returns no errors so don't think that's required